### PR TITLE
Add unique index to Searches

### DIFF
--- a/db/migrate/20200804165723_add_unique_index_to_searches.rb
+++ b/db/migrate/20200804165723_add_unique_index_to_searches.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToSearches < ActiveRecord::Migration[6.0]
+  def change
+    add_index :searches, [:subject, :author, :sort_order], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_04_021511) do
+ActiveRecord::Schema.define(version: 2020_08_04_165723) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -22,6 +22,7 @@ ActiveRecord::Schema.define(version: 2020_08_04_021511) do
     t.string "sort_order"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["subject", "author", "sort_order"], name: "index_searches_on_subject_and_author_and_sort_order", unique: true
   end
 
 end


### PR DESCRIPTION
Searches are validated for uniqueness against :subject, :author and :sort_order.
Adding this index will speed up the existence check for this validation.